### PR TITLE
tr - create fixtures for UCSBDiningCommonsMenuItem table

### DIFF
--- a/frontend/src/fixtures/ucsbDiningCommonsMenuItemFixtures.js
+++ b/frontend/src/fixtures/ucsbDiningCommonsMenuItemFixtures.js
@@ -1,0 +1,30 @@
+const ucsbDiningCommonsMenuItemsFixtures = {
+  oneDiningCommonsMenuItem: {
+    id: 1,
+    diningCommonsCode: "Ortega",
+    name: "Carnitas burrito",
+    station: "Entree",
+  },
+  threeDiningCommonsMenuItems: [
+    {
+      id: 1,
+      diningCommonsCode: "Ortega",
+      name: "Carnitas burrito",
+      station: "Entree",
+    },
+    {
+      id: 2,
+      diningCommonsCode: "DLG",
+      name: "Blueberry crumb pie",
+      station: "Dessert",
+    },
+    {
+      id: 3,
+      diningCommonsCode: "Carrillo",
+      name: "Beef chow mein",
+      station: "Mongolian Grill",
+    },
+  ],
+};
+
+export { ucsbDiningCommonsMenuItemsFixtures };


### PR DESCRIPTION
Closes #9 

In this PR, we add fixtures for the UCSBDiningCommonsMenuItem table in the frontend code.

These will be used for tests and storybook entries later on.