### PR TITLE
sl - copy backend CRUD operations from team01 for articles table

### DIFF
--- a/src/main/java/edu/ucsb/cs156/example/controllers/ArticlesController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/ArticlesController.java
@@ -1,0 +1,164 @@
+package edu.ucsb.cs156.example.controllers;
+import edu.ucsb.cs156.example.entities.Articles;
+import edu.ucsb.cs156.example.entities.UCSBDate;
+import edu.ucsb.cs156.example.errors.EntityNotFoundException;
+import edu.ucsb.cs156.example.repositories.ArticlesRepository;
+import edu.ucsb.cs156.example.repositories.UCSBDateRepository;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.extern.slf4j.Slf4j;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import jakarta.validation.Valid;
+
+import java.time.LocalDateTime;
+import java.time.ZonedDateTime;
+
+/**
+ * This is a REST controller for Articles
+ */
+@Tag(name = "Articles")
+@RequestMapping("/api/articles")
+@RestController
+@Slf4j
+
+public class ArticlesController extends ApiController{
+    
+
+    @Autowired
+    ArticlesRepository articlesRepository;
+
+
+        /**
+     * List all Articles
+     * 
+     * @return an iterable of Articles
+     */
+    @Operation(summary= "List all articles")
+    @PreAuthorize("hasRole('ROLE_USER')")
+    @GetMapping("/all")
+    public Iterable<Articles> allArticles() {
+        Iterable<Articles> articles = articlesRepository.findAll();
+        return articles;
+    }
+
+
+
+    /**
+     * Create a new articles
+     * 
+     * @param title     the title of the articles
+     * @param url        the url of the articles
+     * @param explanation the explanation of the articles
+     * @param email the email of the author
+     * @param dateAdded the date we added the articles with time zone
+     * @return the saved articles
+     */
+    @Operation(summary= "Create a new articles")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @PostMapping("/post")
+    public Articles postArticles(
+            @Parameter(name="title") @RequestParam String title,
+            @Parameter(name="url") @RequestParam String url,
+            @Parameter(name="explanation") @RequestParam String explanation,
+            @Parameter(name="email") @RequestParam String email,
+            @Parameter(name="dateAdded") @RequestParam("dateAdded") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime dateAdded)
+            throws JsonProcessingException {
+
+        // For an explanation of @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+        // See: https://www.baeldung.com/spring-date-parameters
+
+        log.info("dateAdded={}", dateAdded);
+
+        Articles articles = new Articles();
+        articles.setTitle(title);
+        articles.setUrl(url);
+        articles.setExplanation(explanation);
+        articles.setEmail(email);
+        articles.setDateAdded(dateAdded);
+
+        Articles savedArticles = articlesRepository.save(articles);
+
+        return savedArticles;
+    }
+
+    /**
+    * Get a single article by id
+    * 
+    * @param id the id of the article
+    * @return a Articles
+    */
+    @Operation(summary= "Get a single article")
+    @PreAuthorize("hasRole('ROLE_USER')")
+    @GetMapping("")
+    public Articles getById(
+            @Parameter(name="id") @RequestParam Long id) {
+         Articles article = articlesRepository.findById(id)
+               .orElseThrow(() -> new EntityNotFoundException(Articles.class, id));
+
+        return article;
+  }
+
+    /**
+     * Update a single article
+     * 
+     * @param id       id of the article to update
+     * @param incoming the new article
+     * @return the updated article object
+     */
+    @Operation(summary= "Update a single article")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @PutMapping("")
+    public Articles updateArticles(
+            @Parameter(name="id") @RequestParam Long id,
+            @RequestBody @Valid Articles incoming) {
+
+        Articles article = articlesRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException(Articles.class, id));
+
+        article.setTitle(incoming.getTitle());
+        article.setUrl(incoming.getUrl());
+        article.setExplanation(incoming.getExplanation());
+        article.setEmail(incoming.getEmail());
+        article.setDateAdded(incoming.getDateAdded());
+
+        articlesRepository.save(article);
+
+        return article;
+    }
+
+    /**
+     * Delete a Article
+     * 
+     * @param id the id of the article to delete
+     * @return a message indicating the article was deleted
+     */
+    @Operation(summary= "Delete a Article")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @DeleteMapping("")
+    public Object deleteArticle(
+            @Parameter(name="id") @RequestParam Long id) {
+        Articles article = articlesRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException(Articles.class, id));
+
+                articlesRepository.delete(article);
+        return genericMessage("Articles with id %s deleted".formatted(id));
+    }
+
+
+}

--- a/src/main/java/edu/ucsb/cs156/example/entities/Articles.java
+++ b/src/main/java/edu/ucsb/cs156/example/entities/Articles.java
@@ -1,0 +1,35 @@
+package edu.ucsb.cs156.example.entities;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.time.ZonedDateTime;
+
+/**
+ * This is a JPA entity that represents a Github Articles. 
+ */
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Entity(name = "articles")
+public class Articles {
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private long id;
+
+  private String title;
+  private String url;
+  private String explanation;
+  private String email;
+  private LocalDateTime dateAdded;
+
+}

--- a/src/main/java/edu/ucsb/cs156/example/repositories/ArticlesRepository.java
+++ b/src/main/java/edu/ucsb/cs156/example/repositories/ArticlesRepository.java
@@ -1,0 +1,15 @@
+package edu.ucsb.cs156.example.repositories;
+
+import edu.ucsb.cs156.example.entities.Articles;
+
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.stereotype.Repository;
+
+/**
+ * The ArticlesRepository is a repository for Articles entities.
+ */
+
+@Repository
+public interface ArticlesRepository extends CrudRepository<Articles, Long> {
+  
+}

--- a/src/main/resources/db/migration/changes/Articles.json
+++ b/src/main/resources/db/migration/changes/Articles.json
@@ -1,0 +1,74 @@
+{
+    "databaseChangeLog": [
+      {
+        "changeSet": {
+          "id": "Articles-1",
+          "author": "aaasami",
+          "preConditions": [
+            {
+              "onFail": "MARK_RAN"
+            },
+            {
+              "not": [
+                {
+                  "tableExists": {
+                    "tableName": "ARTICLES"
+                  }
+                }
+              ]
+            }
+          ],
+          "changes": [
+            {
+              "createTable": {
+                "columns": [
+                  {
+                    "column": {
+                      "autoIncrement": true,
+                      "constraints": {
+                        "primaryKey": true,
+                        "primaryKeyName": "ARTICLES_PK"
+                      },
+                      "name": "ID",
+                      "type": "BIGINT"
+                    }
+                  },
+                  {
+                    "column": {
+                      "name": "TITLE",
+                      "type": "VARCHAR(255)"
+                    }
+                  },
+                  {
+                    "column": {
+                      "name": "URL",
+                      "type": "VARCHAR(255)"
+                    }
+                  },
+                  {
+                    "column": {
+                      "name": "EXPLANATION",
+                      "type": "VARCHAR(255)"
+                    }
+                  },
+                  {
+                    "column": {
+                      "name": "EMAIL",
+                      "type": "VARCHAR(255)"
+                    }
+                  },
+                  {
+                    "column": {
+                      "name": "DATE_ADDED",
+                      "type": "TIMESTAMP WITH TIME ZONE"
+                    }
+                  }
+                ],
+                "tableName": "ARTICLES"
+              }
+            }
+          ]
+        }
+      }
+    ]
+  }

--- a/src/test/java/edu/ucsb/cs156/example/controllers/ArticlesControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/ArticlesControllerTests.java
@@ -1,0 +1,339 @@
+package edu.ucsb.cs156.example.controllers;
+
+import edu.ucsb.cs156.example.repositories.UserRepository;
+import edu.ucsb.cs156.example.testconfig.TestConfig;
+import edu.ucsb.cs156.example.ControllerTestCase;
+import edu.ucsb.cs156.example.entities.Articles;
+import edu.ucsb.cs156.example.entities.UCSBDate;
+import edu.ucsb.cs156.example.repositories.ArticlesRepository;
+import edu.ucsb.cs156.example.repositories.UCSBDateRepository;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MvcResult;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+
+import java.time.LocalDateTime;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+
+@WebMvcTest(controllers = ArticlesController.class)
+@Import(TestConfig.class)
+public class ArticlesControllerTests extends ControllerTestCase {
+
+    @MockBean
+    ArticlesRepository articlesRepository;
+
+    @MockBean
+    UserRepository userRepository;
+
+    @Autowired
+    ObjectMapper mapper;
+
+    @Test
+    public void logged_out_users_cannot_get_all() throws Exception {
+            mockMvc.perform(get("/api/articles/all"))
+                            .andExpect(status().is(403)); // logged out users can't get all
+    }
+
+    @WithMockUser(roles = { "USER" })
+    @Test
+    public void logged_in_users_can_get_all() throws Exception {
+            mockMvc.perform(get("/api/articles/all"))
+                            .andExpect(status().is(200)); // logged
+    }
+
+    @Test
+    public void logged_out_users_cannot_post() throws Exception {
+            mockMvc.perform(post("/api/articles/post"))
+                            .andExpect(status().is(403));
+    }
+
+    @WithMockUser(roles = { "USER" })
+    @Test
+    public void logged_in_regular_users_cannot_post() throws Exception {
+            mockMvc.perform(post("/api/articles/post"))
+                            .andExpect(status().is(403)); // only admins can post
+    }
+
+    @WithMockUser(roles = { "USER" })
+    @Test
+    public void logged_in_user_can_get_all_articles() throws Exception {
+
+            // arrange
+            LocalDateTime ldt1 = LocalDateTime.parse("2025-04-21T17:00:00");
+
+            Articles article1 = Articles.builder()
+                    .title("sl - create database table fot Articles")
+                    .url("https://github.com/ucsb-cs156-s25/team01-s25-11/commit/8e28ad3216e5156bb0ffbd67164f761635920f41")
+                    .explanation("commit database table")
+                    .email("shuang_li@ucsb.edu")
+                    .dateAdded(ldt1)
+                    .build();
+
+            ArrayList<Articles> expectedArticles = new ArrayList<>();
+            expectedArticles.add(article1);
+
+            when(articlesRepository.findAll()).thenReturn(expectedArticles);
+
+            // act
+            MvcResult response = mockMvc.perform(get("/api/articles/all"))
+                            .andExpect(status().isOk()).andReturn();
+
+            // assert
+
+            verify(articlesRepository, times(1)).findAll();
+            String expectedJson = mapper.writeValueAsString(expectedArticles);
+
+            String responseString = response.getResponse().getContentAsString();
+            assertEquals(expectedJson, responseString);
+    }
+
+    @WithMockUser(roles = { "ADMIN", "USER" })
+    @Test
+    public void admin_user_can_post_new_article() throws Exception {
+        // arrange
+        LocalDateTime ldt1 = LocalDateTime.parse("2025-04-21T17:00:00");
+    
+        Articles article1 = Articles.builder()
+                .title("firstArticles")
+                .url("https://github.com/ucsb-cs156-s25/team01-s25-11/commit/8e28ad3216e5156bb0ffbd67164f761635920f41")
+                .explanation("sl-updated")
+                .email("shuang_li@ucsb.edu")
+                .dateAdded(ldt1)
+                .build();
+    
+        when(articlesRepository.save(eq(article1))).thenReturn(article1);
+
+    
+        // act
+        MvcResult response = mockMvc.perform(
+                post("/api/articles/post?title=firstArticles&url=https://github.com/ucsb-cs156-s25/team01-s25-11/commit/8e28ad3216e5156bb0ffbd67164f761635920f41&email=shuang_li@ucsb.edu&explanation=sl-updated&dateAdded=2025-04-21T17:00:00")
+                    .with(csrf()))
+                .andExpect(status().isOk()).andReturn();
+        
+    
+        // assert
+        verify(articlesRepository, times(1)).save(article1);
+        String expectedJson = mapper.writeValueAsString(article1);
+        String responseString = response.getResponse().getContentAsString();
+        assertEquals(expectedJson, responseString);
+    }
+    
+    @Test
+    public void logged_out_users_cannot_get_by_id() throws Exception {
+            mockMvc.perform(get("/api/articles?id=7"))
+                            .andExpect(status().is(403)); // logged out users can't get by id
+    }
+
+
+    @WithMockUser(roles = { "USER" })
+    @Test
+    public void test_that_logged_in_user_can_get_by_id_when_the_id_does_exist() throws Exception {
+
+            // arrange
+
+            LocalDateTime ldt1 = LocalDateTime.parse("2025-04-21T17:00:00");
+    
+            Articles article1 = Articles.builder()
+                    .title("firstArticles")
+                    .url("https://github.com/ucsb-cs156-s25/team01-s25-11/commit/8e28ad3216e5156bb0ffbd67164f761635920f41")
+                    .explanation("sl-updated")
+                    .email("shuang_li@ucsb.edu")
+                    .dateAdded(ldt1)
+                    .build();
+
+            when(articlesRepository.findById(eq(7L))).thenReturn(Optional.of(article1));
+
+            // act
+            MvcResult response = mockMvc.perform(get("/api/articles?id=7"))
+                            .andExpect(status().isOk()).andReturn();
+
+            // assert
+
+            verify(articlesRepository, times(1)).findById(eq(7L));
+            String expectedJson = mapper.writeValueAsString(article1);
+            String responseString = response.getResponse().getContentAsString();
+            assertEquals(expectedJson, responseString);
+
+    }
+
+
+
+    @WithMockUser(roles = { "USER" })
+    @Test
+    public void test_that_logged_in_user_can_get_by_id_when_the_id_does_not_exist() throws Exception {
+
+            // arrange
+
+            when(articlesRepository.findById(eq(7L))).thenReturn(Optional.empty());
+
+            // act
+            MvcResult response = mockMvc.perform(get("/api/articles?id=7"))
+                            .andExpect(status().isNotFound()).andReturn();
+
+            // assert
+
+            verify(articlesRepository, times(1)).findById(eq(7L));
+            Map<String, Object> json = responseToJson(response);
+            assertEquals("EntityNotFoundException", json.get("type"));
+            assertEquals("Articles with id 7 not found", json.get("message"));
+    }
+
+    @WithMockUser(roles = { "ADMIN", "USER" })
+    @Test
+    public void admin_can_edit_an_existing_article() throws Exception {
+            // arrange
+
+            LocalDateTime ldt1 = LocalDateTime.parse("2022-01-03T00:00:00");
+            LocalDateTime ldt2 = LocalDateTime.parse("2023-01-04T00:00:00");
+
+            Articles article1 = Articles.builder()
+            .title("firstArticles")
+            .url("https://github.com/ucsb-cs156-s25/team01-s25-11/commit/8e28ad3216e5156bb0ffbd67164f761635920f41")
+            .explanation("sl-updated")
+            .email("shuang_li@ucsb.edu")
+            .dateAdded(ldt1)
+            .build();
+
+            Articles editedArticle = Articles.builder()
+            .title("editedArticles")
+            .url("https://github.com/ucsb-cs156-s25/team02-s25-11/commit/8e28ad3216e5156bb0ffbd67164f761635920f41")
+            .explanation("sl-new-explanation")
+            .email("cgaucho@ucsb.edu")
+            .dateAdded(ldt2)
+            .build();
+
+
+            String requestBody = mapper.writeValueAsString(editedArticle);
+
+            when(articlesRepository.findById(eq(67L))).thenReturn(Optional.of(article1));
+
+            // act
+            MvcResult response = mockMvc.perform(
+                            put("/api/articles?id=67")
+                                            .contentType(MediaType.APPLICATION_JSON)
+                                            .characterEncoding("utf-8")
+                                            .content(requestBody)
+                                            .with(csrf()))
+                            .andExpect(status().isOk()).andReturn();
+
+            // assert
+            verify(articlesRepository, times(1)).findById(67L);
+            verify(articlesRepository, times(1)).save(editedArticle); // should be saved with correct user
+            String responseString = response.getResponse().getContentAsString();
+            assertEquals(requestBody, responseString);
+    }
+
+    @WithMockUser(roles = { "ADMIN", "USER" })
+    @Test
+    public void admin_cannot_edit_article_that_does_not_exist() throws Exception {
+            // arrange
+
+            LocalDateTime ldt1 = LocalDateTime.parse("2022-01-03T00:00:00");
+
+            Articles article1 = Articles.builder()
+            .title("firstArticles")
+            .url("https://github.com/ucsb-cs156-s25/team01-s25-11/commit/8e28ad3216e5156bb0ffbd67164f761635920f41")
+            .explanation("sl-updated")
+            .email("shuang_li@ucsb.edu")
+            .dateAdded(ldt1)
+            .build();
+
+
+            String requestBody = mapper.writeValueAsString(article1);
+
+            when(articlesRepository.findById(eq(67L))).thenReturn(Optional.empty());
+
+            // act
+            MvcResult response = mockMvc.perform(
+                            put("/api/articles?id=67")
+                                            .contentType(MediaType.APPLICATION_JSON)
+                                            .characterEncoding("utf-8")
+                                            .content(requestBody)
+                                            .with(csrf()))
+                            .andExpect(status().isNotFound()).andReturn();
+
+            // assert
+            verify(articlesRepository, times(1)).findById(67L);
+            Map<String, Object> json = responseToJson(response);
+            assertEquals("Articles with id 67 not found", json.get("message"));
+
+    }
+
+
+    @WithMockUser(roles = { "ADMIN", "USER" })
+    @Test
+    public void admin_can_delete_a_article() throws Exception {
+            // arrange
+
+            LocalDateTime ldt1 = LocalDateTime.parse("2022-01-03T00:00:00");
+
+            Articles article1 = Articles.builder()
+            .title("firstArticles")
+            .url("https://github.com/ucsb-cs156-s25/team01-s25-11/commit/8e28ad3216e5156bb0ffbd67164f761635920f41")
+            .explanation("sl-updated")
+            .email("shuang_li@ucsb.edu")
+            .dateAdded(ldt1)
+            .build();
+
+
+            when(articlesRepository.findById(eq(15L))).thenReturn(Optional.of(article1));
+
+            // act
+            MvcResult response = mockMvc.perform(
+                            delete("/api/articles?id=15")
+                                            .with(csrf()))
+                            .andExpect(status().isOk()).andReturn();
+
+            // assert
+            verify(articlesRepository, times(1)).findById(15L);
+            verify(articlesRepository, times(1)).delete(eq(article1));
+
+            Map<String, Object> json = responseToJson(response);
+            assertEquals("Articles with id 15 deleted", json.get("message"));
+    }
+
+    @WithMockUser(roles = { "ADMIN", "USER" })
+    @Test
+    public void admin_tries_to_delete_non_existant_ucsbdate_and_gets_right_error_message()
+                    throws Exception {
+            // arrange
+
+            when(articlesRepository.findById(eq(15L))).thenReturn(Optional.empty());
+
+            // act
+            MvcResult response = mockMvc.perform(
+                            delete("/api/articles?id=15")
+                                            .with(csrf()))
+                            .andExpect(status().isNotFound()).andReturn();
+
+            // assert
+            verify(articlesRepository, times(1)).findById(15L);
+            Map<String, Object> json = responseToJson(response);
+            assertEquals("Articles with id 15 not found", json.get("message"));
+    }
+
+
+}


### PR DESCRIPTION
closes to #53 

In this PR, copy over the entity, repository, controller, controller tests, and db migration file (i.e the entire backend CRUD functionality) for the Commits table, from the previous project (team01)

on personal dokku:        https://team02-dev-aaasami.dokku-11.cs.ucsb.edu



# To test:
1.  Fire up application
2. Login
3. Go to swagger
4. Try each of the endpoints

![image](https://github.com/user-attachments/assets/71946d6d-c593-4264-aaf2-9f751c15fe71)
