### PR TITLE
Sd create ucsb organization page

### DIFF
--- a/frontend/src/main/pages/UCSBOrganizations/UCSBOrganizationsCreatePage.js
+++ b/frontend/src/main/pages/UCSBOrganizations/UCSBOrganizationsCreatePage.js
@@ -1,11 +1,49 @@
 import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+import UCSBOrganizationForm from "main/components/UCSBOrganizations/UCSBOrganizationForm";
+import { Navigate } from "react-router-dom";
+import { useBackendMutation } from "main/utils/useBackend";
+import { toast } from "react-toastify";
 
-export default function UCSBOrganizationsCreatePage() {
-  // Stryker disable all : placeholder for future implementation
+export default function UCSBOrganizationCreatePage({ storybook = false }) {
+  const objectToAxiosParams = (ucsbOrganizations) => ({
+    url: "/api/ucsborganizations/post",
+    method: "POST",
+    params: {
+      orgCode: ucsbOrganizations.orgCode,
+      orgTranslationShort: ucsbOrganizations.orgTranslationShort,
+      orgTranslation: ucsbOrganizations.orgTranslation,
+      inactive: ucsbOrganizations.inactive,
+    },
+  });
+
+  const onSuccess = (ucsbOrganizations) => {
+    toast(
+      `New UCSBOrganization Created - OrgCode: ${ucsbOrganizations.orgCode}`,
+    );
+  };
+
+  const mutation = useBackendMutation(
+    objectToAxiosParams,
+    { onSuccess },
+    // Stryker disable next-line all : hard to set up test for caching
+    ["/api/ucsborganizations/all"], // mutation makes this key stale so that pages relying on it reload
+  );
+
+  const { isSuccess } = mutation;
+
+  const onSubmit = async (data) => {
+    mutation.mutate(data);
+  };
+
+  if (isSuccess && !storybook) {
+    return <Navigate to="/ucsborganizations" />;
+  }
+
   return (
     <BasicLayout>
       <div className="pt-2">
-        <h1>Create page not yet implemented</h1>
+        <h1>Create New Organization</h1>
+        <UCSBOrganizationForm submitAction={onSubmit} />
       </div>
     </BasicLayout>
   );

--- a/frontend/src/stories/pages/UCSBOrganizations/UCSBOrganiztionCreatePage.stories.js
+++ b/frontend/src/stories/pages/UCSBOrganizations/UCSBOrganiztionCreatePage.stories.js
@@ -1,0 +1,36 @@
+import React from "react";
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import { http, HttpResponse } from "msw";
+
+import UCSBOrganizationsCreatePage from "main/pages/UCSBOrganizations/UCSBOrganizationsCreatePage";
+
+import { ucsbOrganizationFixtures } from "fixtures/ucsbOrganizationFixtures";
+
+export default {
+  title: "pages/UCSBOrganizations/UCSBOrganizationsCreatePage",
+  component: UCSBOrganizationsCreatePage,
+};
+
+const Template = () => <UCSBOrganizationsCreatePage storybook={true} />;
+
+export const Default = Template.bind({});
+Default.parameters = {
+  msw: [
+    http.get("/api/currentUser", () => {
+      return HttpResponse.json(apiCurrentUserFixtures.userOnly, {
+        status: 200,
+      });
+    }),
+    http.get("/api/systemInfo", () => {
+      return HttpResponse.json(systemInfoFixtures.showingNeither, {
+        status: 200,
+      });
+    }),
+    http.post("/api/ucsborganizations/post", () => {
+      return HttpResponse.json(ucsbOrganizationFixtures.oneOrganization[0], {
+        status: 200,
+      });
+    }),
+  ],
+};

--- a/frontend/src/tests/pages/UCSBOrganizations/UCSBOrganizationsCreatePage.test.js
+++ b/frontend/src/tests/pages/UCSBOrganizations/UCSBOrganizationsCreatePage.test.js
@@ -1,17 +1,42 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import UCSBOrganizationsCreatePage from "main/pages/UCSBOrganizations/UCSBOrganizationsCreatePage";
 import { QueryClient, QueryClientProvider } from "react-query";
 import { MemoryRouter } from "react-router-dom";
 
 import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
 import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+
 import axios from "axios";
 import AxiosMockAdapter from "axios-mock-adapter";
+
+const mockToast = jest.fn();
+jest.mock("react-toastify", () => {
+  const originalModule = jest.requireActual("react-toastify");
+  return {
+    __esModule: true,
+    ...originalModule,
+    toast: (x) => mockToast(x),
+  };
+});
+
+const mockNavigate = jest.fn();
+jest.mock("react-router-dom", () => {
+  const originalModule = jest.requireActual("react-router-dom");
+  return {
+    __esModule: true,
+    ...originalModule,
+    Navigate: (x) => {
+      mockNavigate(x);
+      return null;
+    },
+  };
+});
 
 describe("UCSBOrganizationsCreatePage tests", () => {
   const axiosMock = new AxiosMockAdapter(axios);
 
-  const setupUserOnly = () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
     axiosMock.reset();
     axiosMock.resetHistory();
     axiosMock
@@ -20,15 +45,10 @@ describe("UCSBOrganizationsCreatePage tests", () => {
     axiosMock
       .onGet("/api/systemInfo")
       .reply(200, systemInfoFixtures.showingNeither);
-  };
+  });
 
   const queryClient = new QueryClient();
-  test("Renders expected content", async () => {
-    // arrange
-
-    setupUserOnly();
-
-    // act
+  test("renders without crashing", async () => {
     render(
       <QueryClientProvider client={queryClient}>
         <MemoryRouter>
@@ -37,8 +57,76 @@ describe("UCSBOrganizationsCreatePage tests", () => {
       </QueryClientProvider>,
     );
 
-    // assert
+    await waitFor(() => {
+      expect(screen.getByLabelText("OrgCode")).toBeInTheDocument();
+    });
+  });
 
-    await screen.findByText("Create page not yet implemented");
+  test("on submit, makes request to backend, and redirects to /ucsborganizations", async () => {
+    const queryClient = new QueryClient();
+    const ucsbOrganization = {
+      orgCode: "SKY",
+      orgTranslationShort: "SKY DIVING ORG",
+      orgTranslation: "SKY DIVING ORGANIZATION",
+      inactive: false,
+    };
+
+    axiosMock
+      .onPost("/api/ucsborganizations/post")
+      .reply(202, ucsbOrganization);
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <UCSBOrganizationsCreatePage />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByLabelText("OrgCode")).toBeInTheDocument();
+    });
+
+    const orgCodeInput = screen.getByLabelText("OrgCode");
+    expect(orgCodeInput).toBeInTheDocument();
+
+    const orgTranslationShortInput = screen.getByLabelText(
+      "OrgTranslationShort",
+    );
+    expect(orgTranslationShortInput).toBeInTheDocument();
+
+    const orgTranslationInput = screen.getByLabelText("OrgTranslation");
+    expect(orgTranslationInput).toBeInTheDocument();
+
+    const inactiveInput = screen.getByLabelText("Inactive");
+    expect(inactiveInput).toBeInTheDocument();
+
+    const createButton = screen.getByText("Create");
+    expect(createButton).toBeInTheDocument();
+
+    fireEvent.change(orgCodeInput, { target: { value: "SKY" } });
+    fireEvent.change(orgTranslationShortInput, {
+      target: { value: "SKY DIVING ORG" },
+    });
+    fireEvent.change(orgTranslationInput, {
+      target: { value: "SKY DIVING ORGANIZATION" },
+    });
+    fireEvent.change(inactiveInput, { target: { value: "false" } });
+    fireEvent.click(createButton);
+
+    await waitFor(() => expect(axiosMock.history.post.length).toBe(1));
+
+    expect(axiosMock.history.post[0].params).toEqual({
+      orgCode: "SKY",
+      orgTranslationShort: "SKY DIVING ORG",
+      orgTranslation: "SKY DIVING ORGANIZATION",
+      inactive: "false",
+    });
+
+    // assert - check that the toast was called with the expected message
+    expect(mockToast).toBeCalledWith(
+      "New UCSBOrganization Created - OrgCode: SKY",
+    );
+    expect(mockNavigate).toBeCalledWith({ to: "/ucsborganizations" });
   });
 });


### PR DESCRIPTION
Closes #22

In this PR, we replace the placeholder UCSB Organization Create page with a working Create page. 

Storybook: https://68116e5473a4caf17d64bb60-vdgiimrbjt.chromatic.com/?path=/story/pages-ucsborganizations-ucsborganizationscreatepage--default

To test: 
https://team02-dev-sauld04.dokku-11.cs.ucsb.edu/
1. Login in to this dokku link above
2. Navigate to the create page for UCSB Orgs 
3. Fill in the fields 
4. Click create
5. Check the /api/ucsborganizations/all endpoint with Swagger to see if the new record is in the database 
