### PR TITLE
sd - add UCSBOrganization Index Page, with stories and tests

### DIFF
--- a/frontend/src/main/pages/UCSBOrganizations/UCSBOrganizationsIndexPage.js
+++ b/frontend/src/main/pages/UCSBOrganizations/UCSBOrganizationsIndexPage.js
@@ -1,17 +1,49 @@
-import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+import React from "react";
+import { useBackend } from "main/utils/useBackend";
 
-export default function UCSBOrganizationsIndexPage() {
-  // Stryker disable all : placeholder for future implementation
+import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+import UCSBOrganizationTable from "main/components/UCSBOrganizations/UCSBOrganizationTable";
+import { useCurrentUser, hasRole } from "main/utils/currentUser";
+import { Button } from "react-bootstrap";
+
+export default function UCSBOrganizationIndexPage() {
+  const currentUser = useCurrentUser();
+
+  const {
+    data: ucsborganizations,
+    error: _error,
+    status: _status,
+  } = useBackend(
+    // Stryker disable next-line all : don't test internal caching of React Query
+    ["/api/ucsborganizations/all"],
+    { method: "GET", url: "/api/ucsborganizations/all" },
+    // Stryker disable next-line all : don't test default value of empty list
+    [],
+  );
+
+  const createButton = () => {
+    if (hasRole(currentUser, "ROLE_ADMIN")) {
+      return (
+        <Button
+          variant="primary"
+          href="/ucsborganizations/create"
+          style={{ float: "right" }}
+        >
+          Create ucsborganizations
+        </Button>
+      );
+    }
+  };
+
   return (
     <BasicLayout>
       <div className="pt-2">
-        <h1>Index page not yet implemented</h1>
-        <p>
-          <a href="/ucsborganizations/create">Create</a>
-        </p>
-        <p>
-          <a href="/ucsborganizations/edit/1">Edit</a>
-        </p>
+        {createButton()}
+        <h1>UCSBOrganization</h1>
+        <UCSBOrganizationTable
+          ucsborganizations={ucsborganizations}
+          currentUser={currentUser}
+        />
       </div>
     </BasicLayout>
   );

--- a/frontend/src/stories/pages/UCSBOrganizations/UCSBOrganizationIndexPage.stories.js
+++ b/frontend/src/stories/pages/UCSBOrganizations/UCSBOrganizationIndexPage.stories.js
@@ -1,0 +1,71 @@
+import React from "react";
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import { http, HttpResponse } from "msw";
+
+import UCSBOrganizationsIndexPage from "main/pages/UCSBOrganizations/UCSBOrganizationsIndexPage";
+import { ucsbOrganizationFixtures } from "fixtures/ucsbOrganizationFixtures";
+
+export default {
+  title: "pages/UCSBOrganizations/UCSBOrganizationsIndexPage",
+  component: UCSBOrganizationsIndexPage,
+};
+
+const Template = () => <UCSBOrganizationsIndexPage storybook={true} />;
+
+export const Empty = Template.bind({});
+Empty.parameters = {
+  msw: [
+    http.get("/api/currentUser", () => {
+      return HttpResponse.json(apiCurrentUserFixtures.userOnly, {
+        status: 200,
+      });
+    }),
+    http.get("/api/systemInfo", () => {
+      return HttpResponse.json(systemInfoFixtures.showingNeither, {
+        status: 200,
+      });
+    }),
+    http.get("/api/ucsborganizations/all", () => {
+      return HttpResponse.json([], { status: 200 });
+    }),
+  ],
+};
+
+export const ThreeItemsOrdinaryUser = Template.bind({});
+
+ThreeItemsOrdinaryUser.parameters = {
+  msw: [
+    http.get("/api/currentUser", () => {
+      return HttpResponse.json(apiCurrentUserFixtures.userOnly);
+    }),
+    http.get("/api/systemInfo", () => {
+      return HttpResponse.json(systemInfoFixtures.showingNeither);
+    }),
+    http.get("/api/ucsborganizations/all", () => {
+      return HttpResponse.json(ucsbOrganizationFixtures.threeOrganization);
+    }),
+  ],
+};
+
+export const ThreeItemsAdminUser = Template.bind({});
+
+ThreeItemsAdminUser.parameters = {
+  msw: [
+    http.get("/api/currentUser", () => {
+      return HttpResponse.json(apiCurrentUserFixtures.adminUser);
+    }),
+    http.get("/api/systemInfo", () => {
+      return HttpResponse.json(systemInfoFixtures.showingNeither);
+    }),
+    http.get("/api/ucsborganizations/all", () => {
+      return HttpResponse.json(ucsbOrganizationFixtures.threeOrganization);
+    }),
+    http.delete("/api/ucsborganizations", () => {
+      return HttpResponse.json(
+        { message: "UCSBOrganization deleted successfully" },
+        { status: 200 },
+      );
+    }),
+  ],
+};

--- a/frontend/src/tests/pages/UCSBOrganizations/UCSBOrganizationsIndexPage.test.js
+++ b/frontend/src/tests/pages/UCSBOrganizations/UCSBOrganizationsIndexPage.test.js
@@ -1,15 +1,30 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor, fireEvent } from "@testing-library/react";
 import UCSBOrganizationsIndexPage from "main/pages/UCSBOrganizations/UCSBOrganizationsIndexPage";
 import { QueryClient, QueryClientProvider } from "react-query";
 import { MemoryRouter } from "react-router-dom";
 
+import mockConsole from "jest-mock-console";
+import { ucsbOrganizationFixtures } from "fixtures/ucsbOrganizationFixtures";
+
 import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
 import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+
 import axios from "axios";
 import AxiosMockAdapter from "axios-mock-adapter";
 
+const mockToast = jest.fn();
+jest.mock("react-toastify", () => {
+  const originalModule = jest.requireActual("react-toastify");
+  return {
+    __esModule: true,
+    ...originalModule,
+    toast: (x) => mockToast(x),
+  };
+});
+
 describe("UCSBOrganizationsIndexPage tests", () => {
   const axiosMock = new AxiosMockAdapter(axios);
+  const testId = "UCSBOrganizationTable";
 
   const setupUserOnly = () => {
     axiosMock.reset();
@@ -22,13 +37,22 @@ describe("UCSBOrganizationsIndexPage tests", () => {
       .reply(200, systemInfoFixtures.showingNeither);
   };
 
+  const setupAdminUser = () => {
+    axiosMock.reset();
+    axiosMock.resetHistory();
+    axiosMock
+      .onGet("/api/currentUser")
+      .reply(200, apiCurrentUserFixtures.adminUser);
+    axiosMock
+      .onGet("/api/systemInfo")
+      .reply(200, systemInfoFixtures.showingNeither);
+  };
+
   const queryClient = new QueryClient();
-  test("Renders expected content", async () => {
-    // arrange
 
-    setupUserOnly();
-
-    // act
+  test("Renders with Create Button for admin user", async () => {
+    setupAdminUser();
+    axiosMock.onGet("/api/ucsborganizations/all").reply(200, []);
 
     render(
       <QueryClientProvider client={queryClient}>
@@ -38,13 +62,144 @@ describe("UCSBOrganizationsIndexPage tests", () => {
       </QueryClientProvider>,
     );
 
-    await screen.findByText("Index page not yet implemented");
+    await waitFor(() => {
+      expect(screen.getByText(/Create ucsborganizations/)).toBeInTheDocument();
+    });
+    const button = screen.getByText(/Create ucsborganizations/);
+    expect(button).toHaveAttribute("href", "/ucsborganizations/create");
+    expect(button).toHaveAttribute("style", "float: right;");
+  });
 
-    // assert
+  test("renders threeUCSBOrganizations correctly for regular user", async () => {
+    setupUserOnly();
+    axiosMock
+      .onGet("/api/ucsborganizations/all")
+      .reply(200, ucsbOrganizationFixtures.threeOrganization);
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <UCSBOrganizationsIndexPage />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByTestId(`${testId}-cell-row-0-col-orgCode`),
+      ).toHaveTextContent("ZPR");
+    });
     expect(
-      screen.getByText("Index page not yet implemented"),
-    ).toBeInTheDocument();
-    expect(screen.getByText("Create")).toBeInTheDocument();
-    expect(screen.getByText("Edit")).toBeInTheDocument();
+      screen.getByTestId(`${testId}-cell-row-1-col-orgCode`),
+    ).toHaveTextContent("SKY");
+    expect(
+      screen.getByTestId(`${testId}-cell-row-2-col-orgCode`),
+    ).toHaveTextContent("OSLI");
+
+    const createUCSBOrganizationButton = screen.queryByText(
+      "Create ucsborganizations",
+    );
+    expect(createUCSBOrganizationButton).not.toBeInTheDocument();
+
+    const orgCode = screen.getByText("ZPR");
+    expect(orgCode).toBeInTheDocument();
+
+    const orgTranslationShort = screen.getByTestId(
+      "UCSBOrganizationTable-cell-row-0-col-orgTranslationShort",
+    );
+    expect(orgTranslationShort).toHaveTextContent("Zeta Phi Rho");
+
+    const orgTranslation = screen.getByTestId(
+      "UCSBOrganizationTable-cell-row-0-col-orgTranslation",
+    );
+    expect(orgTranslation).toHaveTextContent("Zeta Phi Rho");
+
+    expect(
+      screen.getByTestId(`${testId}-cell-row-0-col-inactive`),
+    ).toHaveTextContent("false");
+
+    // for non-admin users, details button is visible, but the edit and delete buttons should not be visible
+    expect(
+      screen.queryByTestId(
+        "UCSBOrganizationTable-cell-row-0-col-Delete-button",
+      ),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByTestId("UCSBOrganizationTable-cell-row-0-col-Edit-button"),
+    ).not.toBeInTheDocument();
+  });
+
+  test("renders empty table when backend unavailable, user only", async () => {
+    setupUserOnly();
+
+    axiosMock.onGet("/api/ucsborganizations/all").timeout();
+    const restoreConsole = mockConsole();
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <UCSBOrganizationsIndexPage />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    await waitFor(() => {
+      expect(axiosMock.history.get.length).toBeGreaterThanOrEqual(1);
+    });
+
+    const errorMessage = console.error.mock.calls[0][0];
+    expect(errorMessage).toMatch(
+      "Error communicating with backend via GET on /api/ucsborganizations/all",
+    );
+    restoreConsole();
+  });
+
+  test("what happens when you click delete, admin", async () => {
+    setupAdminUser();
+
+    axiosMock
+      .onGet("/api/ucsborganizations/all")
+      .reply(200, ucsbOrganizationFixtures.threeOrganization);
+    axiosMock
+      .onDelete("/api/ucsborganizations")
+      .reply(200, "UCSBOrganization with orgCode ZPR was deleted");
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <UCSBOrganizationsIndexPage />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByTestId(`${testId}-cell-row-0-col-orgCode`),
+      ).toBeInTheDocument();
+    });
+
+    expect(
+      screen.getByTestId(`${testId}-cell-row-0-col-orgCode`),
+    ).toHaveTextContent("ZPR");
+
+    const deleteButton = screen.getByTestId(
+      `${testId}-cell-row-0-col-Delete-button`,
+    );
+    expect(deleteButton).toBeInTheDocument();
+
+    fireEvent.click(deleteButton);
+
+    await waitFor(() => {
+      expect(mockToast).toBeCalledWith(
+        "UCSBOrganization with orgCode ZPR was deleted",
+      );
+    });
+
+    await waitFor(() => {
+      expect(axiosMock.history.delete.length).toBe(1);
+    });
+    expect(axiosMock.history.delete[0].url).toBe("/api/ucsborganizations");
+    expect(axiosMock.history.delete[0].url).toBe("/api/ucsborganizations");
+    expect(axiosMock.history.delete[0].params).toEqual({ orgCode: "ZPR" });
   });
 });


### PR DESCRIPTION
Closes #23 

In this PR we add the commit index page.

To test, you can visit this dokku deployment:

https://team02-dev-sauld04.dokku-11.cs.ucsb.edu

Visit the UCSB Organization index page. Create and delete should work properly. 

![image](https://github.com/user-attachments/assets/4533840a-654a-4eaa-bb85-dd21709ab367)

Storybook: https://68116e5473a4caf17d64bb60-npxdbiewzu.chromatic.com/?path=/story/pages-ucsborganizations-ucsborganizationsindexpage--empty

