### PR TITLE
sl - add inegration tests for Articles controller endpoints

### DIFF
--- a/src/test/java/edu/ucsb/cs156/example/integration/ArticlesIT.java
+++ b/src/test/java/edu/ucsb/cs156/example/integration/ArticlesIT.java
@@ -1,0 +1,115 @@
+package edu.ucsb.cs156.example.integration;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.annotation.DirtiesContext.ClassMode;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import java.time.LocalDateTime;
+
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+
+import edu.ucsb.cs156.example.entities.Articles;
+import edu.ucsb.cs156.example.repositories.ArticlesRepository;
+import edu.ucsb.cs156.example.repositories.UserRepository;
+import edu.ucsb.cs156.example.services.CurrentUserService;
+import edu.ucsb.cs156.example.services.GrantedAuthoritiesService;
+import edu.ucsb.cs156.example.testconfig.TestConfig;
+
+@ExtendWith(SpringExtension.class)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@AutoConfigureMockMvc
+@ActiveProfiles("integration")
+@Import(TestConfig.class)
+@DirtiesContext(classMode = ClassMode.BEFORE_EACH_TEST_METHOD)
+public class ArticlesIT {
+        @Autowired
+        public CurrentUserService currentUserService;
+
+        @Autowired
+        public GrantedAuthoritiesService grantedAuthoritiesService;
+
+        @Autowired
+        ArticlesRepository articlesRepository;
+
+        @Autowired
+        public MockMvc mockMvc;
+
+        @Autowired
+        public ObjectMapper mapper;
+
+        @MockBean
+        UserRepository userRepository;
+
+        @WithMockUser(roles = { "USER" })
+        @Test
+        public void test_that_logged_in_user_can_get_by_id_when_the_id_exists() throws Exception {
+                // arrange
+
+                LocalDateTime ldt1 = LocalDateTime.parse("2025-04-21T17:00:00");
+        
+                Articles article1 = Articles.builder()
+                        .title("firstArticles")
+                        .url("https://github.com/ucsb-cs156-s25/team01-s25-11/commit/8e28ad3216e5156bb0ffbd67164f761635920f41")
+                        .explanation("sl-updated")
+                        .email("shuang_li@ucsb.edu")
+                        .dateAdded(ldt1)
+                        .build();
+
+                articlesRepository.save(article1);
+
+                // act
+                MvcResult response = mockMvc.perform(get("/api/articles?id=1"))
+                                .andExpect(status().isOk()).andReturn();
+
+                // assert
+                article1.setId(1L);
+                String expectedJson = mapper.writeValueAsString(article1);
+                String responseString = response.getResponse().getContentAsString();
+                assertEquals(expectedJson, responseString);
+        }
+
+        @WithMockUser(roles = { "ADMIN", "USER" })
+        @Test
+        public void an_admin_user_can_post_a_new_article() throws Exception {
+                // arrange
+                LocalDateTime ldt1 = LocalDateTime.parse("2025-04-21T17:00:00");
+
+                Articles article1 = Articles.builder()
+                        .id(1L)
+                        .title("firstArticles")
+                        .url("https://github.com/ucsb-cs156-s25/team01-s25-11/commit/8e28ad3216e5156bb0ffbd67164f761635920f41")
+                        .explanation("sl-updated")
+                        .email("shuang_li@ucsb.edu")
+                        .dateAdded(ldt1)
+                        .build();
+
+                // act
+                MvcResult response = mockMvc.perform(
+                                post("/api/articles/post?title=firstArticles&url=https://github.com/ucsb-cs156-s25/team01-s25-11/commit/8e28ad3216e5156bb0ffbd67164f761635920f41&email=shuang_li@ucsb.edu&explanation=sl-updated&dateAdded=2025-04-21T17:00:00")
+                                                .with(csrf()))
+                                .andExpect(status().isOk()).andReturn();
+
+                // assert
+                String expectedJson = mapper.writeValueAsString(article1);
+                String responseString = response.getResponse().getContentAsString();
+                assertEquals(expectedJson, responseString);
+        }
+}


### PR DESCRIPTION
Closes #121 

in this PR, add 2 integration tests for the Articles table.
 a part of team03